### PR TITLE
Fix: Cannot find 'TARGET_OS_SIMULATOR' in scope

### DIFF
--- a/orderMe/Protocols.swift
+++ b/orderMe/Protocols.swift
@@ -41,6 +41,10 @@ protocol AccessibilityEnabling {
 // MARK: returns true when program runs on simulator and false when on the real device
 struct Platform {
     static var isSimulator: Bool {
-        return TARGET_OS_SIMULATOR != 0
+        #if targetEnvironment(simulator)
+            return true
+        #else
+            return false
+        #endif
     }
 }


### PR DESCRIPTION
I replaced the use of the C macro `TARGET_OS_SIMULATOR` with the Swift-native `#if targetEnvironment(simulator)` conditional compilation flag. This resolves the build error 'Cannot find 'TARGET_OS_SIMULATOR' in scope'.

Note: I could not verify the fix by building the project, as the necessary build tools were not available.